### PR TITLE
Don't clean destination in getFile command

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,13 @@ const singleSlash = /\//g;
 const missingFileRegex =
   /(NT_STATUS_OBJECT_NAME_NOT_FOUND|NT_STATUS_NO_SUCH_FILE)/im;
 
-const getCleanedSmbClientArgs = (args) =>
-  args.map((arg) => `"${arg.replace(singleSlash, "\\")}"`).join(" ");
+const getCleanedSmbClientArgs = (args) => {
+  if (Array.isArray(args)) {
+    return args.map((arg) => `"${arg.replace(singleSlash, "\\")}"`).join(" ");
+  } else {
+    return `"${args.replace(singleSlash, "\\")}"`;
+  }
+}
 
 class SambaClient {
   constructor(options) {
@@ -29,7 +34,7 @@ class SambaClient {
   }
 
   async getFile(path, destination, workingDir) {
-    return await this.execute("get", [path, destination], workingDir);
+    return await this.execute("get", `${getCleanedSmbClientArgs(path)} "${destination}"`, workingDir);
   }
 
   async sendFile(path, destination) {


### PR DESCRIPTION
As a linux user I need to keep a single slash in my `destination` and not a double backslash. With this change, `destination` arg of `getFile` function is not escaped.